### PR TITLE
Update kmeans for PC plots

### DIFF
--- a/inst/rmarkdown/templates/qc_report/skeleton/03_summary_filtered_data.Rmd
+++ b/inst/rmarkdown/templates/qc_report/skeleton/03_summary_filtered_data.Rmd
@@ -185,6 +185,7 @@ if (nrow(pcs) > 0 && sum(complete.cases(pcs[, 1:2])) >= 4) {
   pcs_complete <- pcs[complete.cases(pcs[, 1:2]), , drop = FALSE]
   
   # Perform clustering on complete rows
+  set.seed(123)
   pcs_complete$cluster_k <- as.factor(stats::kmeans(pcs_complete[, 1:2], 4)$cluster)
   
   # Initialize cluster_k as NA
@@ -228,6 +229,7 @@ if (nrow(pcs) > 0 && sum(complete.cases(pcs[, 1:2])) >= 4) {
   pcs_complete <- pcs[complete.cases(pcs[, 1:2]), , drop = FALSE]
 
   # Perform clustering on complete rows
+  set.seed(123)
   pcs_complete$cluster_k <- as.factor(stats::kmeans(pcs_complete[, 1:2], 4)$cluster)
 
   # Initialize cluster_k as NA


### PR DESCRIPTION
Add in a seed so that the clustering is the same for the two rounds this is performed. This prevents mismatch between the colours and groups of the main PC plot and the grid of PC plots